### PR TITLE
Two features: Return actual error object, accepts existing worker instance as constructor argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@
       this.callbacks = {}
       this.terminated = false
       // if opts is undefined, I assume the environment is the worker
-      this.worker = _isFunc(opts) ? new Worker(_fromFuncToURL(opts))
+      this.worker = opts.worker ? opts.worker
+        : _isFunc(opts) ? new Worker(_fromFuncToURL(opts))
         : (_isString(opts) ? new Worker(opts) : self)
       this.worker.onmessage = this[_onIncomingMessage]()
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-worker",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A simpler way of dealing with Web Workers",
   "main": "index.js",
   "homepage": "https://github.com/alvarobernalg/event-worker.git",


### PR DESCRIPTION
Hi @AlvaroBernalG,

I added two features for my personal use and thought I should make you aware of them.

One is just a one-liner. It adds the possibility to inject an already started worker. This is great/necessary when using webpack to import a worker, where you don't really have a filename easily accessible.

The other one is to make sure we actually return the error object, making it possible to throw custom errors and read properties from them and catch them in the caller code.

